### PR TITLE
Update setup-ros

### DIFF
--- a/.github/workflows/colcon_test_build.yaml
+++ b/.github/workflows/colcon_test_build.yaml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - 'ros2'
-  
+
 jobs:
   colcon-test-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: humble
       - uses: ros-tooling/action-ros-ci@v0.2


### PR DESCRIPTION
The workflow doesn't work because of wrong version of EmPy. Issue described here:
https://github.com/colcon/colcon-core/issues/602
and fixed in the v0.7