### PR TITLE
Add RobotState msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(
   "msg/LEDAnimationQueue.msg"
   "msg/LEDImageAnimation.msg"
   "msg/MotorControllerState.msg"
+  "msg/RobotState.msg"
   "msg/RuntimeError.msg"
   "msg/ScriptFlag.msg"
   "msg/SystemStatus.msg"

--- a/msg/RobotState.msg
+++ b/msg/RobotState.msg
@@ -4,5 +4,5 @@ int8 STANDBY = 1
 int8 DOCKING = 2
 int8 SUCCESS = 3
 
-uint16 state_id
+int8 state_id
 string state_name

--- a/msg/RobotState.msg
+++ b/msg/RobotState.msg
@@ -4,5 +4,6 @@ int8 STANDBY = 1
 int8 DOCKING = 2
 int8 SUCCESS = 3
 
+std_msgs/Header header
+
 int8 state_id
-string state_name

--- a/msg/RobotState.msg
+++ b/msg/RobotState.msg
@@ -1,0 +1,8 @@
+int8 ERROR = -1
+int8 E_STOP = 0
+int8 STANDBY = 1
+int8 DOCKING = 2
+int8 SUCCESS = 3
+
+uint16 state_id
+string state_name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `RobotState` message definition to enhance robot state communication.
	- Added integer constants for various robot states: `ERROR`, `E_STOP`, `STANDBY`, `DOCKING`, and `SUCCESS`.
	- Included a standard header for timestamping and frame information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->